### PR TITLE
[37][시스템] 토큰 갱신 수정

### DIFF
--- a/src/main/java/com/ojw/planner/app/system/auth/controller/AuthController.java
+++ b/src/main/java/com/ojw/planner/app/system/auth/controller/AuthController.java
@@ -2,11 +2,13 @@ package com.ojw.planner.app.system.auth.controller;
 
 import com.ojw.planner.app.system.auth.domain.dto.RefreshDto;
 import com.ojw.planner.app.system.auth.domain.log.dto.LoginRequest;
+import com.ojw.planner.app.system.auth.domain.log.dto.LoginResponse;
 import com.ojw.planner.app.system.auth.service.AuthService;
 import com.ojw.planner.core.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -27,7 +29,10 @@ public class AuthController {
     @Operation(summary = "로그인", tags = "Auth")
     @PostMapping(path = "/login")
     public ResponseEntity<?> login(@RequestBody @Valid LoginRequest request) {
-        return new ResponseEntity<>(new ApiResponse<>(authService.login(request)), HttpStatus.OK);
+        LoginResponse response = authService.login(request);
+        return ResponseEntity.ok()
+                .header(authService.generateRefreshCookie(response.getRefreshToken()))
+                .body(response);
     }
 
     @Operation(summary = "로그아웃", tags = "Auth")
@@ -42,8 +47,8 @@ public class AuthController {
 
     @Operation(summary = "토큰 갱신", tags = "Auth")
     @PostMapping(path = "/refresh")
-    public ResponseEntity<?> refresh(@RequestBody @Valid RefreshDto refreshDto) {
-        return new ResponseEntity<>(new ApiResponse<>(authService.refresh(refreshDto)), HttpStatus.OK);
+    public ResponseEntity<?> refresh(HttpServletRequest request) {
+        return new ResponseEntity<>(new ApiResponse<>(authService.refresh(request)), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/ojw/planner/app/system/auth/domain/log/dto/LoginResponse.java
+++ b/src/main/java/com/ojw/planner/app/system/auth/domain/log/dto/LoginResponse.java
@@ -1,5 +1,6 @@
 package com.ojw.planner.app.system.auth.domain.log.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ public class LoginResponse {
 
     private String accessToken;
 
+    @JsonIgnore
     private String refreshToken;
 
 }

--- a/src/main/java/com/ojw/planner/config/SecurityConfig.java
+++ b/src/main/java/com/ojw/planner/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                 , "/webjars/**"
                 , "/error"
                 , "/auth/login"
+                , "/auth/refresh"
         );
     }
 


### PR DESCRIPTION
- 로그인 시 refresh token을 response body에서 쿠키로 변경
- 토큰 갱신 시, refresh token을 쿠키에서 체크하는 것으로 변경
- access token을 프론트에서 휘발성 메모리 등에 저장을 위해 토큰 갱신 API filter ignore 처리