### PR TITLE
[39][시스템] 인증 및 사용자 관리 이슈사항 수정

### DIFF
--- a/src/main/java/com/ojw/planner/app/system/auth/controller/AuthController.java
+++ b/src/main/java/com/ojw/planner/app/system/auth/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
     public ResponseEntity<?> login(@RequestBody @Valid LoginRequest request) {
         LoginResponse response = authService.login(request);
         return ResponseEntity.ok()
-                .header(authService.generateRefreshCookie(response.getRefreshToken()))
+                .header(HttpHeaders.SET_COOKIE, authService.generateRefreshCookie(response.getRefreshToken()))
                 .body(response);
     }
 

--- a/src/main/java/com/ojw/planner/app/system/auth/service/AuthService.java
+++ b/src/main/java/com/ojw/planner/app/system/auth/service/AuthService.java
@@ -49,11 +49,11 @@ public class AuthService {
     @Transactional
     public LoginResponse login(LoginRequest request) {
 
-        User user = userService.getUser(request.getUserId());
+        User user = userService.getUser(request.getUserId(), true);
         if(!passwordEncoder.matches(request.getPassword(), user.getPassword()))
-            throw new ResponseException("Password is wrong", HttpStatus.UNAUTHORIZED);
+            throw new ResponseException("아이디 혹은 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED);
 
-        if(user.getIsBanned()) throw new ResponseException("banned user : " + request.getUserId(), HttpStatus.FORBIDDEN);
+        if(user.getIsBanned()) throw new ResponseException("정지된 유저 : " + request.getUserId(), HttpStatus.FORBIDDEN);
 
         String accessToken = jwtUtil.createToken(user, JwtType.ACCESS);
         String refreshToken = jwtUtil.createToken(user, JwtType.REFRESH);
@@ -123,7 +123,7 @@ public class AuthService {
             if(!jwtUtil.validateToken(jwt, JwtType.REFRESH))
                 throw new ResponseException("Invalid refresh token", HttpStatus.UNAUTHORIZED);
         } catch (ExpiredJwtException e) {
-            throw new ResponseException("Refresh token is expired. Please login again.", HttpStatus.FORBIDDEN);
+            throw new ResponseException("세션이 만료되었습니다. 다시 로그인 해주세요.", HttpStatus.FORBIDDEN);
         }
 
     }

--- a/src/main/java/com/ojw/planner/app/system/user/domain/dto/UserCreateDto.java
+++ b/src/main/java/com/ojw/planner/app/system/user/domain/dto/UserCreateDto.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class UserCreateDto {
 
     @NotBlank
-    @Schema(description = "사용자아아디")
+    @Schema(description = "사용자 아이디")
     private String userId;
 
     @NotBlank

--- a/src/main/java/com/ojw/planner/app/system/user/domain/dto/UserUpdateDto.java
+++ b/src/main/java/com/ojw/planner/app/system/user/domain/dto/UserUpdateDto.java
@@ -2,9 +2,11 @@ package com.ojw.planner.app.system.user.domain.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/ojw/planner/app/system/user/domain/dto/redis/PwdResetRequest.java
+++ b/src/main/java/com/ojw/planner/app/system/user/domain/dto/redis/PwdResetRequest.java
@@ -1,0 +1,27 @@
+package com.ojw.planner.app.system.user.domain.dto.redis;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "비밀번호 재설정 요청")
+public class PwdResetRequest {
+
+    @NotBlank
+    @Schema(description = "사용자 아이디")
+    private String userId;
+
+    @NotBlank
+    @Schema(description = "재설정 키")
+    private String key;
+
+    @NotBlank
+    @Schema(description = "비밀번호")
+    private String password;
+
+}

--- a/src/main/java/com/ojw/planner/app/system/user/domain/redis/PwdResetKey.java
+++ b/src/main/java/com/ojw/planner/app/system/user/domain/redis/PwdResetKey.java
@@ -1,0 +1,24 @@
+package com.ojw.planner.app.system.user.domain.redis;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@Builder
+@RedisHash("pResetKey")
+public class PwdResetKey {
+
+    @Id
+    private String key;
+
+    private String userId;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long expire;
+
+}

--- a/src/main/java/com/ojw/planner/app/system/user/repository/UserRepository.java
+++ b/src/main/java/com/ojw/planner/app/system/user/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, String>, UserReposit
 
     Optional<User> findByEmailAndIsDeletedIsFalse(String email);
 
+    Optional<User> findByEmailAndUserIdNotAndIsDeletedIsFalse(String email, String userId);
+
 }

--- a/src/main/java/com/ojw/planner/app/system/user/repository/redis/PwdResetKeyRepository.java
+++ b/src/main/java/com/ojw/planner/app/system/user/repository/redis/PwdResetKeyRepository.java
@@ -1,0 +1,7 @@
+package com.ojw.planner.app.system.user.repository.redis;
+
+import com.ojw.planner.app.system.user.domain.redis.PwdResetKey;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PwdResetKeyRepository extends CrudRepository<PwdResetKey, String> {
+}

--- a/src/main/java/com/ojw/planner/app/system/user/service/UserFacadeService.java
+++ b/src/main/java/com/ojw/planner/app/system/user/service/UserFacadeService.java
@@ -3,26 +3,40 @@ package com.ojw.planner.app.system.user.service;
 import com.ojw.planner.app.community.board.service.comment.notification.BoardCommentNotificationService;
 import com.ojw.planner.app.planner.schedule.service.request.notification.ScheduleShareRequestNotificationService;
 import com.ojw.planner.app.system.friend.service.request.notification.FriendRequestNotificationService;
+import com.ojw.planner.app.system.user.domain.dto.redis.PwdResetRequest;
+import com.ojw.planner.app.system.user.domain.redis.PwdResetKey;
 import com.ojw.planner.app.system.user.domain.security.CustomUserDetails;
+import com.ojw.planner.app.system.user.service.redis.PwdResetKeyService;
 import com.ojw.planner.core.domain.Notification;
+import com.ojw.planner.exception.ResponseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class UserFacadeService {
 
+    @Value("${spring.data.redis.expire.password}")
+    private Long passwordExpire;
+
+    private final UserService userService;
+
     private final FriendRequestNotificationService friendRequestNotificationService;
 
     private final ScheduleShareRequestNotificationService shareRequestNotificationService;
 
     private final BoardCommentNotificationService notificationService;
+
+    private final PwdResetKeyService pwdResetKeyService;
 
     /**
     * 사용자 알림 목록 조회
@@ -38,6 +52,42 @@ public class UserFacadeService {
 
         Collections.sort(notifications, (n1, n2) -> n2.getRegDtm().compareTo(n1.getRegDtm()));
         return notifications;
+
+    }
+
+    /**
+     * 비밀번호 재설정 메일 전송
+     *
+     * @param userId - 사용자 아이디
+     */
+    public void sendPasswordReset(String userId) {
+
+        String key = pwdResetKeyService.saveKey(
+                PwdResetKey.builder()
+                        .userId(userId)
+                        .key(UUID.randomUUID().toString())
+                        .expire(passwordExpire)
+                        .build()
+        );
+
+        userService.sendPasswordReset(userId, key);
+
+    }
+
+    /**
+     * 비밀번호 재설정
+     *
+     * @param request - 재설정 요청
+     */
+    @Transactional
+    public void userPasswordReset(PwdResetRequest request) {
+
+        PwdResetKey key = pwdResetKeyService.getKey(request.getKey());
+        if(key == null) throw new ResponseException("잘못된 요청입니다.", HttpStatus.BAD_REQUEST);
+        if(!key.getUserId().equalsIgnoreCase(request.getUserId()))
+            throw new ResponseException("잘못된 요청입니다.", HttpStatus.BAD_REQUEST);
+
+        userService.userPasswordReset(request);
 
     }
 

--- a/src/main/java/com/ojw/planner/app/system/user/service/redis/PwdResetKeyService.java
+++ b/src/main/java/com/ojw/planner/app/system/user/service/redis/PwdResetKeyService.java
@@ -1,0 +1,22 @@
+package com.ojw.planner.app.system.user.service.redis;
+
+import com.ojw.planner.app.system.user.domain.redis.PwdResetKey;
+import com.ojw.planner.app.system.user.repository.redis.PwdResetKeyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PwdResetKeyService {
+
+    private final PwdResetKeyRepository pwdResetKeyRepository;
+
+    public String saveKey(PwdResetKey key) {
+        return pwdResetKeyRepository.save(key).getKey();
+    }
+
+    public PwdResetKey getKey(String key) {
+        return pwdResetKeyRepository.findById(key).orElse(null);
+    }
+
+}

--- a/src/main/java/com/ojw/planner/config/SecurityConfig.java
+++ b/src/main/java/com/ojw/planner/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                 , "/error"
                 , "/auth/login"
                 , "/auth/refresh"
+                , "/user/auth/**"
         );
     }
 

--- a/src/main/java/com/ojw/planner/core/util/SMTPUtil.java
+++ b/src/main/java/com/ojw/planner/core/util/SMTPUtil.java
@@ -5,12 +5,17 @@ import jakarta.mail.*;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
 public class SMTPUtil {
+
+    @Value("${spring.mail.username}")
+    private String from;
 
     private final JavaMailSender mailSender;
 
@@ -19,6 +24,9 @@ public class SMTPUtil {
         try {
 
             MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+            helper.setFrom(from, "Planner");
+
             message.addRecipient(Message.RecipientType.TO, new InternetAddress(request.getTo()));
             message.setSubject(request.getSubject());
             message.setContent(request.getBody() != null ? request.getBody() : "", "text/html; charset=UTF-8");

--- a/src/main/java/com/ojw/planner/core/util/dto/smtp/SMTPRequest.java
+++ b/src/main/java/com/ojw/planner/core/util/dto/smtp/SMTPRequest.java
@@ -14,9 +14,27 @@ public class SMTPRequest {
 
     private String body;
 
-    //TODO : UI 작업 시 템플릿 작업
-    public SMTPRequest passwordReset(String userId) {
-        this.body = "";
+    public SMTPRequest findId(String userId, String home) {
+        this.body = "[Planner]<br />" +
+                "요청하신 아이디 찾기 결과입니다.<br />" +
+                "아이디 : " + userId + "<br />" +
+                "<br />" +
+                "<a href=\"" + home + "\">로그인하기</a><br />" +
+                "문의사항은 회신 부탁드립니다. 감사합니다.";
+
+        return this;
+    }
+
+    public SMTPRequest passwordReset(String userId, String url, String key) {
+        this.body = "[Planner]<br />" +
+                "아래 링크를 눌러 비밀번호를 재설정해주세요.<br />" +
+                "<a href=\"" + url +
+                "?userId=" + userId +
+                "&key=" + key +
+                "\">비밀번호 재설정</a><br />" +
+                "<br />" +
+                "문의사항은 회신 부탁드립니다. 감사합니다.";
+
         return this;
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,10 +29,16 @@ spring:
           auth: ${PL_MAIL_PROPERTIES_MAIL_SMTP_AUTH}
           starttls:
             enable: ${PL_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE}
+    path:
+      home: ${PL_MAIL_PATH_HOME}
+      password: ${PL_MAIL_PATH_PASSWORD}
+
   data:
     redis:
       host: ${PL_REDIS_HOST}
       port: ${PL_REDIS_PORT}
+      expire:
+        password: ${PL_REDIS_EXPIRE_PASSWORD}
 
   rabbitmq:
     host: ${PL_MQ_HOST}


### PR DESCRIPTION
- 로그인 API에서 refresh token HttpHeaders.SET_COOKIE에 세팅
- 인증 관련 에러 메세지 한글로 변경
- 로그인 에러 메세지 수정(아이디 및 비밀번호 구분 없이)
- 인증 관련 API 추가
- 사용자 API 1 depth로 구성된 API는 경로에 사용자 아이디를 받는 CRUD API와 겹칠 수 있기 때문에, 2 depth 구분